### PR TITLE
Export types for LinkedListNode, TTestFunction and TMapFunction

### DIFF
--- a/src/LinkedList.ts
+++ b/src/LinkedList.ts
@@ -1,14 +1,16 @@
 import LinkedListNode from './LinkedListNode';
 
+export { LinkedListNode };
+
 /** Type used for filter and find methods, returning a boolean */
-type TTestFunction<NodeData> = (
+export type TTestFunction<NodeData> = (
   data: NodeData,
   index: number,
   list: LinkedList<NodeData>,
 ) => boolean;
 
 /** Type used for map and forEach methods, returning anything */
-type TMapFunction<NodeData> = (
+export type TMapFunction<NodeData> = (
   data: any,
   index: number,
   list: LinkedList<NodeData>,


### PR DESCRIPTION
Allows `LinkedListNode`, `TTestFunction` and `TMapFunction` to be imported along with the default `LinkedList`. For example: 

```ts
import LinkedList, { LinkedListNode, TTestFunction, TMapFunction } from 'ts-linked-list';
```

Changes are super minimal but should be enough to solve #44 :)